### PR TITLE
add encode arg

### DIFF
--- a/scripts/make_cache.py
+++ b/scripts/make_cache.py
@@ -12,7 +12,7 @@ parser.add_argument("--dataset_path", type=str, default="./tmp/finetuning_datase
 
 args = parser.parse_args()
 
-with open(args.dataset_path, "r") as f:
+with open(args.dataset_path, "r", encoding="utf8") as f:
     data = json.load(f)
 
 PROMPT_DICT = {


### PR DESCRIPTION
fine tuning을 위한 hdf5 파일을 생성하기 위해 make_cache.py 실행 중, UnicodeDecodeError 발생.
.load에 encoding="utf-8" 인자를 전달하여 해결
![tmp1](https://github.com/yoonhero/jamo_llm/assets/121370909/5e0d5e09-6dc3-4f69-8754-d392e7f8e195)
